### PR TITLE
Add GitHub-driven Astro Pages deploy workflow

### DIFF
--- a/.github/workflows/astro-pages-deploy.yml
+++ b/.github/workflows/astro-pages-deploy.yml
@@ -1,0 +1,66 @@
+name: Astro Pages deploy
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'site/**'
+      - 'content/**'
+      - '.github/workflows/astro-pages-deploy.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'site/**'
+      - 'content/**'
+      - '.github/workflows/astro-pages-deploy.yml'
+
+concurrency:
+  group: astro-pages-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      PUBLIC_GA_MEASUREMENT_ID: ${{ vars.PUBLIC_GA_MEASUREMENT_ID }}
+      PUBLIC_DISQUS_SHORTNAME: ${{ vars.PUBLIC_DISQUS_SHORTNAME }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: site/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build site
+        run: pnpm build
+
+      - name: Derive Pages branch name
+        run: echo "CF_PAGES_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}" >> "$GITHUB_ENV"
+
+      - name: Skip deploy when Cloudflare credentials are not configured
+        if: ${{ env.CLOUDFLARE_ACCOUNT_ID == '' || env.CLOUDFLARE_PAGES_PROJECT == '' || env.CLOUDFLARE_API_TOKEN == '' }}
+        run: |
+          echo "Cloudflare Pages deploy is not configured for this repository."
+          echo "Set repo vars CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_PAGES_PROJECT and secret CLOUDFLARE_API_TOKEN to enable auto deploys."
+
+      - name: Deploy to Cloudflare Pages
+        if: ${{ env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_PAGES_PROJECT != '' && env.CLOUDFLARE_API_TOKEN != '' }}
+        run: npx wrangler pages deploy dist --project-name "$CLOUDFLARE_PAGES_PROJECT" --branch "$CF_PAGES_BRANCH"

--- a/.github/workflows/astro-site-ci.yml
+++ b/.github/workflows/astro-site-ci.yml
@@ -6,6 +6,7 @@ on:
       - 'site/**'
       - 'content/**'
       - '.github/workflows/astro-site-ci.yml'
+      - '.github/workflows/astro-pages-deploy.yml'
   push:
     branches:
       - master
@@ -13,6 +14,7 @@ on:
       - 'site/**'
       - 'content/**'
       - '.github/workflows/astro-site-ci.yml'
+      - '.github/workflows/astro-pages-deploy.yml'
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ site/public/CNAME
 !site/src/lib/
 !site/src/lib/**
 
+# Cloudflare / Wrangler
+.wrangler/
+
 # Unit test / coverage reports
 .coverage
 .tox

--- a/docs/plans/cloudflare-pages-deployment.md
+++ b/docs/plans/cloudflare-pages-deployment.md
@@ -9,6 +9,15 @@
 - **Node version:** `24`
 - **Package manager:** `pnpm`
 
+## Current repository automation shape
+
+This repo currently uses **GitHub Actions direct uploads** to Cloudflare Pages rather than Cloudflare's native Git provider integration.
+
+That means:
+- Cloudflare Pages may still show `Git Provider: No`
+- preview and production deploys are triggered by `.github/workflows/astro-pages-deploy.yml`
+- Astro is built in GitHub Actions, then uploaded with `wrangler pages deploy`
+
 ## Production env vars
 
 Set as needed in Cloudflare Pages:
@@ -18,6 +27,23 @@ Set as needed in Cloudflare Pages:
 - `UNSPLASH_ACCESS_KEY` (only if sync runs in CI/build; otherwise keep sync manual)
 - `UNSPLASH_USERNAME=suicide_chewbacca`
 - `UNSPLASH_REFERRAL_SOURCE=ashwch.com`
+
+## GitHub Actions settings for direct-upload deploys
+
+Set these in the GitHub repository so Actions builds preserve production behavior:
+
+### Repository variables
+
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_PAGES_PROJECT=ashwch-main-site`
+- `PUBLIC_GA_MEASUREMENT_ID`
+- `PUBLIC_DISQUS_SHORTNAME` (optional; Astro currently defaults to `ashwch` in production)
+
+### Repository secrets
+
+- `CLOUDFLARE_API_TOKEN`
+
+Use a scoped Cloudflare API token with Pages/Workers write access for this account. Do **not** use a personal OAuth refresh token from local Wrangler config in CI.
 
 ## Recommended rollout shape
 


### PR DESCRIPTION
## Summary

This PR adds the GitHub-driven Cloudflare Pages deploy workflow for the Astro site and documents the repository-level settings required to keep preview/production deploys working without losing Google Analytics.

## What changed

- add `.github/workflows/astro-pages-deploy.yml`
  - builds Astro on PRs and `master`
  - deploys via `wrangler pages deploy`
  - safely skips deploy if Cloudflare credentials are not configured
  - supports manual `workflow_dispatch`
- update `.github/workflows/astro-site-ci.yml`
  - include the deploy workflow file in the path triggers so workflow-only changes still run Astro checks
- update `docs/plans/cloudflare-pages-deployment.md`
  - document that this repo uses GitHub Actions direct uploads rather than native Cloudflare Git integration
  - document the required repo variables/secrets
- ignore local Wrangler cache with `.wrangler/`

## External configuration already applied

Outside of git, I already configured the Cloudflare/GitHub settings needed for analytics continuity:

- created the Cloudflare Pages project: `ashwch-main-site`
- set GitHub repository variables:
  - `CLOUDFLARE_ACCOUNT_ID`
  - `CLOUDFLARE_PAGES_PROJECT`
  - `PUBLIC_GA_MEASUREMENT_ID=G-8G7DZ59108`
  - `PUBLIC_DISQUS_SHORTNAME=ashwch`
- set Cloudflare Pages project secrets:
  - `PUBLIC_GA_MEASUREMENT_ID`
  - `PUBLIC_DISQUS_SHORTNAME`
- redeployed the current production Pages site with GA enabled so `ashwch-main-site.pages.dev` is not missing analytics

## Remaining manual step

The workflow intentionally does **not** store a personal local Wrangler OAuth refresh token in GitHub Actions.

To activate automatic deploys, add this GitHub repository secret manually:

- `CLOUDFLARE_API_TOKEN`

Use a scoped Cloudflare API token with Pages/Workers write access for account `0d1e7713fd55da534e4a09782c4e4bdc`.

Until that secret is added:
- CI/build still runs
- deploy steps skip cleanly
- existing manual/production Pages deployments keep working

## How to test

```bash
cd site
pnpm check
pnpm build
```

After the PR merges and `CLOUDFLARE_API_TOKEN` is added:
1. trigger `Astro Pages deploy` manually with `workflow_dispatch`, or push a small follow-up commit
2. confirm PR branches publish preview aliases
3. confirm `master` pushes update `https://ashwch-main-site.pages.dev/`
