### PR TITLE
Preserve legacy html URLs on the Astro custom domain

### DIFF
--- a/cloudflare/ashwch-astro-domain-proxy.mjs
+++ b/cloudflare/ashwch-astro-domain-proxy.mjs
@@ -1,0 +1,83 @@
+const ROBOTS_TXT = `User-agent: *
+Allow: /
+
+Sitemap: https://ashwch.com/sitemap-index.xml
+`;
+
+function isBodylessMethod(method) {
+  return method === 'GET' || method === 'HEAD';
+}
+
+function buildUpstreamUrl(requestUrl) {
+  const upstream = new URL(requestUrl);
+  upstream.protocol = 'https:';
+  upstream.hostname = 'ashwch-main-site.pages.dev';
+
+  if (upstream.pathname !== '/' && upstream.pathname.endsWith('.html')) {
+    upstream.pathname = upstream.pathname.slice(0, -5);
+  }
+
+  return upstream;
+}
+
+async function fetchFollowingPagesRedirects(request, upstreamUrl) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('Host', 'ashwch-main-site.pages.dev');
+
+  let currentUrl = upstreamUrl;
+  let response;
+
+  for (let redirects = 0; redirects < 5; redirects += 1) {
+    response = await fetch(currentUrl.toString(), {
+      method: request.method,
+      headers: requestHeaders,
+      body: isBodylessMethod(request.method) ? undefined : request.body,
+      redirect: 'manual',
+    });
+
+    if (![301, 302, 307, 308].includes(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get('Location');
+    if (!location) {
+      return response;
+    }
+
+    currentUrl = new URL(location, currentUrl);
+    currentUrl.protocol = 'https:';
+    currentUrl.hostname = 'ashwch-main-site.pages.dev';
+  }
+
+  return response;
+}
+
+export default {
+  async fetch(request) {
+    const incomingUrl = new URL(request.url);
+
+    if (incomingUrl.hostname === 'www.ashwch.com') {
+      const redirectUrl = new URL(request.url);
+      redirectUrl.hostname = 'ashwch.com';
+      return Response.redirect(redirectUrl.toString(), 301);
+    }
+
+    if (incomingUrl.pathname === '/robots.txt') {
+      return new Response(ROBOTS_TXT, {
+        headers: {
+          'content-type': 'text/plain; charset=utf-8',
+          'cache-control': 'public, max-age=0, must-revalidate',
+        },
+      });
+    }
+
+    const upstreamUrl = buildUpstreamUrl(request.url);
+    const response = await fetchFollowingPagesRedirects(request, upstreamUrl);
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  },
+};

--- a/docs/plans/cloudflare-pages-deployment.md
+++ b/docs/plans/cloudflare-pages-deployment.md
@@ -18,6 +18,20 @@ That means:
 - preview and production deploys are triggered by `.github/workflows/astro-pages-deploy.yml`
 - Astro is built in GitHub Actions, then uploaded with `wrangler pages deploy`
 
+## Custom-domain route preservation
+
+Cloudflare Pages normalizes `.html` routes on its project domain (for example `/pages/about.html` → `/pages/about`).
+Because preserving legacy `.html` URLs is launch-critical for `ashwch.com`, the custom domain is fronted by a small Worker proxy:
+
+- source: `cloudflare/ashwch-astro-domain-proxy.mjs`
+- routes: `ashwch.com/*`, `www.ashwch.com/*`
+- behavior:
+  - preserve legacy `.html` URLs by mapping them to the corresponding clean Pages routes upstream
+  - keep `www.ashwch.com` redirected to apex
+  - proxy the custom domain to `ashwch-main-site.pages.dev`
+
+If the Pages project is redeployed or recreated, keep this Worker route in place or legacy `.html` parity will regress on the custom domain.
+
 ## Production env vars
 
 Set as needed in Cloudflare Pages:
@@ -43,7 +57,13 @@ Set these in the GitHub repository so Actions builds preserve production behavio
 
 - `CLOUDFLARE_API_TOKEN`
 
-Use a scoped Cloudflare API token with Pages/Workers write access for this account. Do **not** use a personal OAuth refresh token from local Wrangler config in CI.
+Use a scoped Cloudflare API token with Pages write access for this account. Do **not** use a personal OAuth refresh token from local Wrangler config in CI.
+
+## Worker deployment note
+
+The current Worker route was deployed manually with local Wrangler OAuth credentials because the existing GitHub Actions token is scoped for Pages deploys, not arbitrary Worker/route management.
+
+If you want to automate `cloudflare/ashwch-astro-domain-proxy.mjs`, create a separate Cloudflare API token with Workers + Routes permissions and wire a dedicated workflow for it.
 
 ## Recommended rollout shape
 

--- a/docs/plans/redirect-map.md
+++ b/docs/plans/redirect-map.md
@@ -17,14 +17,20 @@ Because launch-critical URLs are preserved, the redirect surface is intentionall
 
 ## Aliases configured in `site/public/_redirects`
 
-- `/writing` → `/writing.html` (301)
-- `/writing/` → `/writing.html` (301)
 - `/about` → `/pages/about.html` (301)
 - `/about/` → `/pages/about.html` (301)
 - `/projects` → `/pages/projects.html` (301)
 - `/projects/` → `/pages/projects.html` (301)
 - `/photography` → `/pages/photography.html` (301)
 - `/photography/` → `/pages/photography.html` (301)
+
+## Custom-domain preservation note
+
+Cloudflare Pages normalizes `.html` routes on the project domain, so `ashwch.com` uses a custom-domain Worker proxy to preserve legacy `.html` URLs externally.
+
+That means:
+- `https://ashwch-main-site.pages.dev/pages/about.html` may redirect to `/pages/about`
+- `https://ashwch.com/pages/about.html` must continue to work as a stable legacy URL
 
 ## Notes
 

--- a/site/public/_redirects
+++ b/site/public/_redirects
@@ -1,5 +1,3 @@
-/writing /writing.html 301
-/writing/ /writing.html 301
 /about /pages/about.html 301
 /about/ /pages/about.html 301
 /projects /pages/projects.html 301


### PR DESCRIPTION
## Summary

This PR codifies the custom-domain `.html` preservation fix for the Astro cutover.

## What changed

- remove the `/writing` ↔ `/writing.html` redirect pair from `site/public/_redirects`
  - this looped on Cloudflare Pages because Pages normalizes `.html` to clean URLs by default
- add `cloudflare/ashwch-astro-domain-proxy.mjs`
  - preserves legacy `.html` URLs on `ashwch.com`
  - redirects `www.ashwch.com` to apex
  - proxies the custom domain to `ashwch-main-site.pages.dev`
- document the custom-domain worker behavior in:
  - `docs/plans/cloudflare-pages-deployment.md`
  - `docs/plans/redirect-map.md`

## Why

Cloudflare Pages serves the Astro site correctly, but its project domain normalizes legacy `.html` routes such as:
- `/pages/about.html` → `/pages/about`
- `/protecting-our-own-tenant-in-a-multi-tenant-saas.html` → `/protecting-our-own-tenant-in-a-multi-tenant-saas`

That breaks the launch-critical URL preservation policy for `ashwch.com`.

The live fix uses a small Worker in front of the custom domain so the public site can keep legacy `.html` URLs even though the underlying Pages project uses clean-path normalization.

## Live status

The custom-domain worker has already been deployed live as an operational hotfix so:
- `https://ashwch.com/pages/about.html` returns `200`
- `https://ashwch.com/protecting-our-own-tenant-in-a-multi-tenant-saas.html` returns `200`
- `https://ashwch.com/writing.html` returns `200`
- `https://www.ashwch.com/...` redirects to apex

This PR records that fix in source control.

## Checks run

```bash
cd site
pnpm check
pnpm build

node --check cloudflare/ashwch-astro-domain-proxy.mjs
```
