### PR TITLE
Add canonical AI engineering article and repost workflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ node --check cloudflare/ashwch-astro-domain-proxy.mjs
 
 Root `content/` remains the source of truth.
 
+For article authoring and cross-site reposts with `engineering.diversio.com`, read:
+
+- `docs/runbooks/blog-reposting.md` — explains why `ashwch.com` owns the full article, why the engineering site keeps a short stub, and which files/commands to use
+
 If you touch photography-related flows, current helpers are:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Notes:
 - Static pages live in `content/pages/*.md`
 - Shared images live in `content/images/**`
 - Shared acronym definitions live in `abbreviations.md`
+- Cross-site repost workflow: `docs/runbooks/blog-reposting.md` (why one site owns the full article and the other keeps a short stub)
 
 Astro migration/sync scripts:
 

--- a/content/articles/how-we-use-ai-like-engineers.md
+++ b/content/articles/how-we-use-ai-like-engineers.md
@@ -1,0 +1,148 @@
+Title: How we use AI like engineers
+Date: 2026-05-20
+Modified: 2026-05-20
+Category: Engineering
+Tags: engineering, ai, developer-experience, workflow
+Slug: how-we-use-ai-like-engineers
+Authors: Ashwini Chaudhary
+Summary: Using AI to recover context in large codebases and take repetitive work off engineers' plates without compromising on code and review quality or operational safety.
+
+Context engineering and management is a hard problem and is the highest priority even before a single line of code is written.
+
+> Note: The article uses the term AI and LLM interchangeably. What I mean is a mix of chat-based AI tools and agentic tools like Claude Code, Cursor, Codex CLI, and even newer desktop apps like Claude CoWork and Codex.
+
+It's very common for a person operating on LLMs to ask for too much in one pass. This often results in a gigantic diff that leaves the engineer doing the hard part afterward: figuring out what the change actually means and whether it even includes everything they asked for to begin with. The second problem is that the resulting code review often does not give either the engineer or the LLM enough reasoning to produce a high-quality review that really addresses the diff from a business-logic and code-quality point of view.
+
+What has worked for us over time is to create narrower contexts for AI and allow AI to recover context faster without being married to the same LLM session where we actually started the discussion with the AI. Having a workflow built around this significantly helps with producing high quality work and work is broken down into small chunks that are easier to review and catch mistakes early.
+
+At a high level, the shape of the work matters more than the amount of output:
+
+<figure>
+  <img
+    src="{static}/images/articles/how-we-use-ai-like-engineers/big-diff-vs-small-drafts.svg"
+    alt="Comparison between one large AI-generated change and several smaller reviewable drafts."
+    style="width:100%;height:auto;display:block;"
+  />
+  <figcaption>Smaller drafts are easier to review and easier to reason about.</figcaption>
+</figure>
+
+## Where it actually helps
+
+The current models are ridiculously good at discovering code related to logic that spans various repos, and our [switching to a mono-repo last year](/the-monolith-that-made-ai-actually-useful.html) when Claude Code was starting to pick up has made a huge difference for us.
+
+Saying AI is good at this doesn't mean an engineer isn't able to do the same. The difference is that assembling all of those files, conventions, blast-radius clues, and related pieces is simply faster than starting from zero and jumping around in code manually. That itself saves significant time upfront and lets us guide the AI if it's looking in the wrong places. Sometimes it points to old dead code, which is not what we want. AI also loves to ignore existing utilities and redefine them every chance it gets, which is why it still requires steering from the engineer.
+
+Additionally, AI helps with the skeleton tests and docs that will be needed, along with any renaming that is supposed to happen and stay consistent across many files. And if the task is broken down into small enough subtasks, those guardrails are even easier for AI to follow.
+
+## Context matters more than prompting
+
+While we were discovering these patterns ourselves as we got more familiar with Anthropic's Sonnet/Opus and OpenAI's Codex, the final clarity we needed to apply them across all of our repos came from this blog from [OpenAI Engineering](https://openai.com/index/harness-engineering/). Boris Cherny has also talked publicly about why the concept of an index (used by GitHub Copilot and Cursor) does not hold up as well for these more powerful LLMs anymore: they prefer to explore code every time, and indexing breaks down if you have hundreds of feature branches because you effectively need a different index for each branch.
+
+Since then we have made significant changes to our AGENTS.md and CLAUDE.md files and have a custom skill that helped us achieve it and we use it with any new project as well.
+
+The bigger gains usually come from giving the model a structure it can work inside:
+
+- table of contents under each project
+- role of each project relative to other projects in the monorepo
+- stable project instructions
+- clear repository conventions
+- useful ignore pattern (but not too many)
+- obvious quality gates
+- enough architectural context to make the connections obvious
+
+Configuration shape matters too. Reusable rules should stay reusable (branching conventions, deployment, CI checks, etc.). Project-specific context should stay close to the project (this includes subfolders with their own AGENTS.md/CLAUDE.md). Technical controls like tool restrictions or ignore behavior should stay out of narrative guidance. We have since moved all of these to skills, and those skills know when to execute a certain script and why.
+
+These might sound boring because they sometimes require telling the LLM about things here and there, but the upsides are much higher. It also works naturally for humans. Dense documentation with everything dumped into it is hard for us to follow too; a clean split between shared standards and project-specific setup is easier for humans to maintain and easier for models to use effectively.
+
+The split we try to preserve looks roughly like this:
+
+<figure>
+  <img
+    src="{static}/images/articles/how-we-use-ai-like-engineers/context-belongs-in-different-places.svg"
+    alt="Diagram showing that shared standards, project docs, and skills or controls belong in different places instead of being mixed together."
+    style="width:100%;height:auto;display:block;"
+  />
+  <figcaption>Shared standards, project docs, and operational controls should not be mixed together.</figcaption>
+</figure>
+
+## The workflow still has to hold up
+
+For a workflow to hold up, it needs to have very clear and specific guidelines for that workflow and these should be very easy to review and maintain for humans.
+
+A big feature is still broken down into smaller releases and stacked PRs as much as possible. We really believe and take pride in building systems that do not keep us up at night at 3AM, late heroics when a bug is identified (worse if identified by a client) and solved are much less appreciated.
+
+Any bug identified is still first proven by adding that missing test that did not catch it earlier and then the fix is implemented to make the test pass. This practice has worked really well for us the last 8 years.
+
+Anything that touches the core of our system and has direct implications for our clients is still thoroughly tested manually on external sandboxes with production-like data to give us extra confirmation that we are not relying solely on automated tests. This often also includes testing non-happy-path flows.
+
+It's very easy to waste time asking AI for too much at once. The output can look productive for a bit because it has generated a lot of text, but now we have to pay in engineer time to validate the draft and ensure the intent is spot on.
+
+Hence, our focus nowadays is heavily on narrower and more practical planning and that is made possible by faster context recovery, smaller drafts, quicker iteration cycle when something looks off.
+
+## What still stays human
+
+Some work should stay obviously human.
+
+If the change touches existing data, authorization, or production infrastructure, someone has to reason about it and test it first in environments where we are fine experimenting. AI's assistance is helpful, but we cannot trust it with everything. One example for us is that we build a lot of internal tools for our team, and it is easy for AI to confuse those with client-facing features, so we need to steer it back in the right direction when that happens.
+
+This applies to architecture as well. Difficult calls around coupling, isolation, and long-term maintenance belong to engineers because they understand the wider system, know about upcoming business decisions, and are the ones who will have to live with the consequences. A simple example of this was when we were building SMS-based pulse surveys. We really wanted a backend like Django's local console email backend that would let us test SMS without ever sending a real message, but the configuration still needed to be plug-and-play so the functionality stayed the same for our team. An LLM cannot plan for that, nor can you write it once in your AGENTS.md and assume it will do it correctly for each feature.
+
+Final approval stays human too. Anything we ship is the engineer's responsibility at the end of the day. Saying the LLM missed it does not work for us, and it will not work for our clients either.
+
+This boundary matters more than any model benchmark:
+
+<figure>
+  <img
+    src="{static}/images/articles/how-we-use-ai-like-engineers/ai-accelerates-humans-own-risk.svg"
+    alt="Diagram showing that AI accelerates drafting and context recovery while humans keep responsibility for risk, architecture, and final approval."
+    style="width:100%;height:auto;display:block;"
+  />
+  <figcaption>AI can accelerate drafting, but risk, architecture, and approval still stay human.</figcaption>
+</figure>
+
+## Evaluating AI like infrastructure
+
+There is a second layer to this beyond coding workflow: choosing the right AI stack.
+
+What I have found useful about these systems is thinking about them the way we think about infrastructure. While the model is definitely important, the surrounding ecosystem matters a lot as well.
+
+The things I care about:
+
+- developer experience (DX)
+- how well the ecosystem is supported across the world
+- how easy it is to onboard engineers to it (is it too overwhelming?)
+- how easily engineers can build on top of it
+- what it changes about data handling and compliance
+- what this decision will cost over time, not just in a demo. The cost is both engineer time and company cost.
+
+DX is a big deal for me, more than the model itself.
+
+This does not mean we have not made mistakes. We have tried a lot of different things, but thanks to the team we were able to switch away from them when we realized something was not working for us. A recent example for us was completely moving away from Claude Code and Codex CLI to Pi within a week.
+
+## What changed for us
+
+- We now recover context much faster and avoid the dumb zone.
+- We turn repeated friction into instructions, tools, or guardrails more often. The goal is to always spend less time on low-leverage repetition and more time on design, review, and testing.
+
+A lot of that progress came from engineers comparing notes ([`/insights` in CLAUDE.md](https://x.com/trq212/status/2019173731042750509) was helpful, and we also started doing monthly [code review discussions](https://engineering.diversio.com/docs/code-review-digest-writer/) to avoid common and repeated mistakes), tightening instructions, and writing down what actually worked. The primary reason for our success with these systems, though, is our team (and this includes all teams across Diversio), who have kept feeding their learning back into it.
+
+## The part that matters most
+
+AI acts as a force multiplier when it sits on top of a culture with strong engineering habits. The fact that we had already built that culture well before LLMs were a thing has worked in our favour.
+
+If you're wondering where to start to make the most of it with your own team, start by working on planning, scoping, instructions, code-quality and testing guardrails, and review loops. Build systems and workflows that can be maintained and owned by the whole team, and spend less time on model comparison.
+
+## Related reading
+
+- [The Monolith That Made AI Actually Useful](/the-monolith-that-made-ai-actually-useful.html)
+- [No Code by Hand](/no-code-by-hand-agentic-platform-acceleration.html)
+- [Postman to Bruno: A Weekend Migration That Transformed Our API Workflow](/from-postman-to-bruno-how-ai-changed-our-api-workflow.html)
+
+<div class="ai-disclaimer">
+  <p class="ai-disclaimer-title">AI writing disclaimer</p>
+  <ul>
+    <li>The article was verified for typos and basic grammatical mistakes using Codex 5.4.</li>
+    <li>The references to our existing blog posts were included with the help of Codex 5.4 (we left comments for it).</li>
+    <li>The SVGs were generated using Codex 5.4 and Excalidraw MCP.</li>
+  </ul>
+</div>

--- a/content/articles/the-monolith-that-made-ai-actually-useful.md
+++ b/content/articles/the-monolith-that-made-ai-actually-useful.md
@@ -70,7 +70,7 @@ Each directory is its own git repository. But they all live in one workspace. On
 
 ### From Days to Hours
 
-Our product manager [Sam](https://www.linkedin.com/in/samuel-bonin/) now redesigns features in hours, not days. He pulls the latest code, runs migrations, and has AI analyze our Bruno API collections. Remember when we [migrated from Postman to Bruno]({filename}/articles/from-postman-to-bruno-how-ai-changed-our-api-workflow.md)? That decision pays huge dividends in a monolith.
+Our product manager [Sam](https://www.linkedin.com/in/samuel-bonin/) now redesigns features in hours, not days. He pulls the latest code, runs migrations, and has AI analyze our Bruno API collections. Remember when we [migrated from Postman to Bruno](/from-postman-to-bruno-how-ai-changed-our-api-workflow.html)? That decision pays huge dividends in a monolith.
 
 The workflow looks like this:
 

--- a/content/images/articles/how-we-use-ai-like-engineers/ai-accelerates-humans-own-risk.svg
+++ b/content/images/articles/how-we-use-ai-like-engineers/ai-accelerates-humans-own-risk.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" role="img" aria-labelledby="title desc">
+  <title id="title">Wireframe: AI accelerates. Humans own the risk.</title>
+  <desc id="desc">A grayscale wireframe showing what AI accelerates and what humans still own.</desc>
+  <defs>
+    <style>
+      .title { font: 700 32px "Plus Jakarta Sans", "Helvetica Neue", Inter, Arial, sans-serif; fill: #111318; }
+      .subtitle { font: 600 14px "Helvetica Neue", Inter, Arial, sans-serif; fill: #4e5563; }
+      .panelTitle { font: 700 20px "Plus Jakarta Sans", "Helvetica Neue", Inter, Arial, sans-serif; fill: #111318; }
+      .item { font: 600 16px "Helvetica Neue", Inter, Arial, sans-serif; fill: #2f3640; }
+      .small { font: 700 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #4e5563; letter-spacing: .08em; }
+    </style>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#2f3640" />
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="520" fill="#fafafb" />
+
+  <text x="48" y="68" class="title">AI accelerates. Humans own the risk.</text>
+  <text x="48" y="94" class="subtitle">Draft with AI. Keep decisions human.</text>
+
+  <!-- left field -->
+  <rect x="72" y="180" width="344" height="208" rx="12" fill="#eceff3" />
+  <text x="104" y="216" class="panelTitle">AI accelerates</text>
+  <circle cx="108" cy="254" r="5" fill="#2f3640" />
+  <text x="126" y="260" class="item">Context recovery</text>
+  <circle cx="108" cy="296" r="5" fill="#2f3640" />
+  <text x="126" y="302" class="item">Test drafts</text>
+  <circle cx="108" cy="338" r="5" fill="#2f3640" />
+  <text x="126" y="344" class="item">Docs drafts</text>
+
+  <!-- center bridge -->
+  <line x1="416" y1="286" x2="540" y2="286" stroke="#2f3640" stroke-width="2" marker-end="url(#arrow)" />
+  <text x="448" y="266" class="small">HUMAN-GUIDED</text>
+
+  <!-- right field -->
+  <rect x="544" y="180" width="344" height="208" rx="12" fill="#f7f8fa" />
+  <rect x="544" y="180" width="5" height="208" rx="2.5" fill="#2f3640" />
+  <text x="576" y="216" class="panelTitle">Human owns</text>
+  <circle cx="580" cy="254" r="5" fill="#2f3640" />
+  <text x="598" y="260" class="item">Data + auth risk</text>
+  <circle cx="580" cy="296" r="5" fill="#2f3640" />
+  <text x="598" y="302" class="item">Architecture</text>
+  <circle cx="580" cy="338" r="5" fill="#2f3640" />
+  <text x="598" y="344" class="item">Final approval</text>
+</svg>

--- a/content/images/articles/how-we-use-ai-like-engineers/big-diff-vs-small-drafts.svg
+++ b/content/images/articles/how-we-use-ai-like-engineers/big-diff-vs-small-drafts.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" role="img" aria-labelledby="title desc">
+  <title id="title">Wireframe: One big diff vs small drafts</title>
+  <desc id="desc">A grayscale editorial wireframe showing one overloaded change on the left becoming four smaller reviewable pull requests on the right.</desc>
+  <defs>
+    <style>
+      .title { font: 700 34px "Plus Jakarta Sans", "Helvetica Neue", Inter, Arial, sans-serif; fill: #111318; }
+      .label { font: 700 26px "Plus Jakarta Sans", "Helvetica Neue", Inter, Arial, sans-serif; fill: #111318; }
+      .small { font: 600 15px "Helvetica Neue", Inter, Arial, sans-serif; fill: #4e5563; }
+      .module { font: 700 18px "Plus Jakarta Sans", "Helvetica Neue", Inter, Arial, sans-serif; fill: #111318; }
+      .mono { font: 700 12px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #353b45; letter-spacing: .08em; }
+    </style>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#2f3640" />
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="520" fill="#fafafb" />
+
+  <text x="48" y="68" class="title">One big diff vs small drafts</text>
+
+  <!-- left overloaded slab -->
+  <g>
+    <rect x="72" y="128" width="256" height="256" rx="16" fill="#d7dbe2" stroke="#2a2f38" stroke-width="2" />
+    <text x="96" y="166" class="label">One big diff</text>
+
+    <rect x="96" y="196" width="176" height="22" rx="6" fill="#f5f6f8" />
+    <rect x="96" y="232" width="150" height="22" rx="6" fill="#f5f6f8" />
+    <rect x="96" y="268" width="188" height="22" rx="6" fill="#f5f6f8" />
+    <rect x="96" y="304" width="164" height="22" rx="6" fill="#f5f6f8" />
+    <rect x="96" y="340" width="206" height="22" rx="6" fill="#f5f6f8" />
+
+    <!-- slight compression cue -->
+    <rect x="288" y="340" width="32" height="22" rx="6" fill="#f5f6f8" opacity="0.7" />
+  </g>
+
+  <!-- transition -->
+  <g>
+    <line x1="392" y1="270" x2="548" y2="270" stroke="#2f3640" stroke-width="3" marker-end="url(#arrow)" />
+    <text x="430" y="244" class="mono">BREAK IT DOWN</text>
+  </g>
+
+  <!-- right modular stack -->
+  <g>
+    <rect x="584" y="136" width="272" height="42" rx="10" fill="#cfd4dc" stroke="#2a2f38" stroke-width="1.5" />
+    <text x="606" y="163" class="module">PR 1</text>
+
+    <rect x="584" y="196" width="272" height="42" rx="10" fill="#e6e9ee" stroke="#8b919c" stroke-width="1.5" />
+    <text x="606" y="223" class="module">PR 2</text>
+
+    <rect x="584" y="256" width="272" height="42" rx="10" fill="#e6e9ee" stroke="#8b919c" stroke-width="1.5" />
+    <text x="606" y="283" class="module">PR 3</text>
+
+    <rect x="584" y="316" width="272" height="42" rx="10" fill="#e6e9ee" stroke="#8b919c" stroke-width="1.5" />
+    <text x="606" y="343" class="module">PR 4</text>
+  </g>
+
+  <!-- note -->
+  <g>
+    <text x="652" y="420" class="small">Clearer intent</text>
+    <text x="652" y="444" class="small">Lower blast radius</text>
+  </g>
+</svg>

--- a/content/images/articles/how-we-use-ai-like-engineers/context-belongs-in-different-places.svg
+++ b/content/images/articles/how-we-use-ai-like-engineers/context-belongs-in-different-places.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" role="img" aria-labelledby="title desc">
+  <title id="title">Split context by purpose</title>
+  <desc id="desc">A grayscale wireframe showing that standards, project docs, and skills or controls should not be mixed together.</desc>
+  <defs>
+    <style>
+      .title { font: 700 32px "Plus Jakarta Sans", "Helvetica Neue", Inter, Arial, sans-serif; fill: #111318; }
+      .subtitle { font: 600 14px "Helvetica Neue", Inter, Arial, sans-serif; fill: #4e5563; }
+      .laneTitle { font: 700 18px "Plus Jakarta Sans", "Helvetica Neue", Inter, Arial, sans-serif; fill: #111318; }
+      .item { font: 600 15px "Helvetica Neue", Inter, Arial, sans-serif; fill: #2f3640; }
+      .small { font: 700 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #4e5563; letter-spacing: .08em; }
+      .note { font: 600 14px "Helvetica Neue", Inter, Arial, sans-serif; fill: #4e5563; }
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="520" fill="#fafafb" />
+
+  <text x="48" y="68" class="title">Split context by purpose</text>
+  <text x="48" y="94" class="subtitle">Reusable rules, project docs, and skills should not live in one blob.</text>
+
+  <!-- four-column layout -->
+  <g>
+    <text x="72" y="150" class="small">MIXED</text>
+    <text x="284" y="150" class="small">SEPARATED</text>
+
+    <rect x="72" y="172" width="184" height="224" rx="14" fill="#eceff3" stroke="#8b919c" stroke-width="1.5" />
+    <text x="96" y="208" class="laneTitle">One mixed doc</text>
+    <text x="96" y="250" class="item">Standards</text>
+    <text x="96" y="284" class="item">Docs</text>
+    <text x="96" y="318" class="item">Controls</text>
+    <text x="96" y="362" class="small">ALL TOGETHER</text>
+    <text x="96" y="388" class="note">Hard to maintain</text>
+
+    <rect x="284" y="172" width="184" height="224" rx="14" fill="#eceff3" stroke="#8b919c" stroke-width="1.5" />
+    <text x="308" y="208" class="laneTitle">Standards</text>
+    <text x="308" y="250" class="item">Branching</text>
+    <text x="308" y="284" class="item">Deploy</text>
+    <text x="308" y="318" class="item">CI checks</text>
+    <text x="308" y="362" class="small">REUSABLE</text>
+
+    <rect x="496" y="172" width="184" height="224" rx="14" fill="#f7f8fa" stroke="#8b919c" stroke-width="1.5" />
+    <text x="520" y="208" class="laneTitle">Project docs</text>
+    <text x="520" y="250" class="item">TOC</text>
+    <text x="520" y="284" class="item">Role</text>
+    <text x="520" y="318" class="item">Architecture</text>
+    <text x="520" y="362" class="small">NEAR CODE</text>
+
+    <rect x="708" y="172" width="184" height="224" rx="14" fill="#eceff3" stroke="#8b919c" stroke-width="1.5" />
+    <text x="732" y="208" class="laneTitle">Skills</text>
+    <text x="732" y="250" class="item">Tool rules</text>
+    <text x="732" y="284" class="item">Ignore rules</text>
+    <text x="732" y="318" class="item">Scripts</text>
+    <text x="732" y="362" class="small">OPERATIONAL</text>
+  </g>
+</svg>

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@ This directory contains current project documentation for the Astro-based `ashwc
 - `plans/astro-rollback-plan.md`
 - `plans/redirect-map.md`
 
-### Workflow docs
+### Runbooks and workflow docs
+- `runbooks/blog-reposting.md`
 - `workflows/PHOTOGRAPHY_WORKFLOW.md`
 
 ## Historical docs

--- a/docs/runbooks/blog-reposting.md
+++ b/docs/runbooks/blog-reposting.md
@@ -1,0 +1,286 @@
+# Blog Reposting Runbook
+
+Use this runbook when one article needs to appear in two places:
+
+- the **full article** should live on `ashwch.com`
+- a **short discovery stub** should live on `engineering.diversio.com`
+
+## Why this runbook exists
+
+We now have two public writing surfaces:
+
+- `ashwch.com` — Ashwini's personal site
+- `engineering.diversio.com` — Diversio's engineering site
+
+A cross-post only works well if one place clearly owns the full article.
+Without that rule, we quickly create avoidable problems:
+
+- two full copies that drift apart
+- unclear canonical ownership for search engines
+- internal links that point at the wrong site shape
+- image paths that work in one repo but break in the other
+
+This runbook exists to keep the workflow simple and repeatable.
+
+## First principles
+
+1. **One article should have one canonical home.**
+   Search engines and future editors both need a single source of truth.
+
+2. **The personal site is source-driven from root `content/`.**
+   Generated files under `site/src/content/**` are build artifacts, not authoring files.
+
+3. **The engineering site already has a repost model.**
+   That repo understands `sourceType: repost`, `sourceUrl`, and `canonicalUrl`.
+
+4. **The personal site does not have repost metadata yet.**
+   It always treats articles as local canonical pages.
+
+Because of those constraints, the supported direction today is:
+
+```text
+ashwch.com owns the full article
+           ↓
+engineering.diversio.com carries a short repost stub
+```
+
+If product requirements change, change the code model first. Do not fake a reverse
+workflow in content.
+
+## Mental model
+
+Think of the two repos like this:
+
+```text
+ashwch.github.io                         engineering-website
+-----------------                        -------------------
+content/articles/<slug>.md              src/content/blog/<slug>.md
+        │                                       │
+        │ full article                          │ short repost stub
+        ▼                                       ▼
+site/src/content/articles/<slug>.md     /blog/<slug>/
+(generated)                             on engineering.diversio.com
+        │
+        ▼
+/<slug>.html
+on ashwch.com
+```
+
+And article assets flow like this on the personal site:
+
+```text
+content/images/articles/<slug>/diagram.svg
+        │
+        │ pnpm sync:assets
+        ▼
+site/public/images/articles/<slug>/diagram.svg
+        │
+        ▼
+/images/articles/<slug>/diagram.svg
+in the built site
+```
+
+## When to use this workflow
+
+Use this workflow when all of these are true:
+
+- the article is authored for Ashwini's personal site
+- the full body should keep its long-term canonical home on `ashwch.com`
+- the engineering site should still surface it to engineering readers
+
+## Personal-site workflow
+
+### Step 1: Add the full article source file
+
+Create:
+
+- `content/articles/<slug>.md`
+
+Use the legacy metadata format this repo already expects:
+
+```md
+Title: My Article Title
+Date: 2026-05-20
+Modified: 2026-05-20
+Category: Engineering
+Tags: engineering, ai, workflow
+Slug: my-article-title
+Authors: Ashwini Chaudhary
+Summary: One-sentence summary.
+```
+
+### Why this format exists
+
+This repo still uses a migration script that reads the old metadata style and
+rewrites it into Astro frontmatter during sync.
+
+So:
+
+- edit `content/articles/*.md`
+- do **not** hand-edit `site/src/content/articles/*.md`
+- do **not** switch one article to YAML frontmatter unless the pipeline changes
+
+### Step 2: Add article images in the right place
+
+Create:
+
+- `content/images/articles/<slug>/`
+
+Reference them from the article like this:
+
+```html
+<img src="{static}/images/articles/<slug>/diagram.svg" alt="...">
+```
+
+### Why this path shape exists
+
+The personal-site sync pipeline rewrites `{static}/images/...` into a public site
+path during build.
+
+That means:
+
+- **source markdown** should use `{static}/images/...`
+- **built HTML** will use `/images/...`
+
+### Step 3: Rewrite links for the personal-site URL model
+
+The personal site does **not** use `/blog/<slug>/` article URLs.
+It uses `/<slug>.html`.
+
+So when you port a full article into this repo, rewrite links like this:
+
+```text
+Before: /blog/the-monolith-that-made-ai-actually-useful/
+After:  /the-monolith-that-made-ai-actually-useful.html
+```
+
+If the article needs to link back to engineering-site docs or skills pages, use
+absolute URLs instead of local `/docs/...` paths:
+
+```text
+Before: /docs/code-review-digest-writer
+After:  https://engineering.diversio.com/docs/code-review-digest-writer/
+```
+
+### Why this matters
+
+Relative route shapes are different across the two repos.
+What works on the engineering site can silently become a broken or misleading link
+on the personal site.
+
+### Step 4: Validate locally
+
+From `site/` run:
+
+```bash
+pnpm check
+pnpm build
+```
+
+If you stay inside `site/`, useful spot checks are:
+
+```bash
+rg -n 'canonical' dist/<slug>.html
+rg -n '/images/articles/<slug>/' dist/<slug>.html
+```
+
+Expected result:
+
+- canonical URL is `https://ashwch.com/<slug>.html`
+- article images resolve from `/images/articles/<slug>/...`
+
+## Engineering-site follow-up
+
+After the personal site is correct, update your `engineering-website` checkout.
+
+Create or convert:
+
+- `src/content/blog/<slug>.md`
+
+Use a short repost stub with these fields:
+
+```yaml
+sourceType: repost
+sourceSiteName: ashwch.com
+sourceUrl: https://ashwch.com/<slug>.html
+canonicalUrl: https://ashwch.com/<slug>.html
+```
+
+Body shape:
+
+- one line saying it was originally published on `ashwch.com`
+- one short excerpt or setup paragraph
+- one “Read the full post on ashwch.com →” link
+
+### Why the engineering copy should stay short
+
+The engineering repo is not the canonical owner in this workflow.
+Keeping a short stub prevents drift and makes the ownership obvious to both readers
+and future editors.
+
+### Editorial recommendation
+
+Repost stubs usually should **not** keep `featured: true` unless there is a
+specific editorial reason to feature a link-out card.
+
+### Validate the engineering-side stub too
+
+From your `engineering-website` checkout run:
+
+```bash
+npm run build
+```
+
+Useful spot checks there:
+
+```bash
+rg -n 'canonical' dist/blog/<slug>/index.html
+rg -n 'ashwch.com/<slug>.html' dist/blog/<slug>/index.html
+```
+
+Expected result:
+
+- the engineering blog page builds successfully
+- the canonical URL points to `https://ashwch.com/<slug>.html`
+- the page body stays short and links to the canonical article
+
+## Common mistakes to avoid
+
+### Do not do this
+
+```text
+✗ Edit site/src/content/articles/<slug>.md directly
+✓ Edit content/articles/<slug>.md
+```
+
+```text
+✗ Leave /blog/<slug>/ links inside the personal canonical copy
+✓ Rewrite them to /<slug>.html
+```
+
+```text
+✗ Use local /docs/... links in the personal article when the target lives on the engineering site
+✓ Use absolute https://engineering.diversio.com/docs/... URLs
+```
+
+```text
+✗ Keep two full article bodies in both repos without a clear reason
+✓ Keep one full body and one short repost stub
+```
+
+## If requirements change
+
+If you want this instead:
+
+```text
+engineering.diversio.com owns the full article
+           ↓
+ashwch.com carries a repost or external canonical
+```
+
+stop and add product/code support first.
+
+Today the personal-site repo always emits local `ashwch.com` canonicals for
+articles and does not have a repost content model.
+
+That is a code-model limitation, not an editorial preference.

--- a/site/README.md
+++ b/site/README.md
@@ -101,5 +101,6 @@ Current live setup:
 
 ## Related docs
 
+- content repost workflow: `../docs/runbooks/blog-reposting.md` (canonical ownership, link rewriting, asset paths, and validation commands)
 - migration plan: `../docs/plans/astro-migration-plan.md`
 - repository deployment caveats: `../AGENTS.md`


### PR DESCRIPTION
## Summary

This PR adds the canonical `ashwch.com` version of **How we use AI like engineers** and documents the supported cross-site repost workflow for future editors and LLMs.

### What changed

| Area | Change |
|---|---|
| Canonical article | Added the full article under `content/articles/how-we-use-ai-like-engineers.md` |
| Images | Added the three SVG assets under `content/images/articles/how-we-use-ai-like-engineers/` |
| Link hygiene | Rewrote article links to the personal-site `/<slug>.html` route model |
| Docs | Added a first-principles repost runbook and linked it from the main repo entrypoints |
| Cleanup | Fixed the broken Postman/Bruno link in `the-monolith-that-made-ai-actually-useful.md` |

## Why

We now publish writing to two public sites:

- `ashwch.com`
- `engineering.diversio.com`

This PR makes `ashwch.com` the clear canonical owner for this article and documents the rule so we do not end up with:

- two full copies drifting apart
- mismatched canonical URLs
- broken internal links caused by different route shapes
- asset paths that work in one repo but not the other

## Mental model

```text
ashwch.com owns the full article
           ↓
engineering.diversio.com carries a short repost stub
```

## Files to review

<details>
<summary>Canonical article + assets</summary>

- `content/articles/how-we-use-ai-like-engineers.md`
- `content/images/articles/how-we-use-ai-like-engineers/ai-accelerates-humans-own-risk.svg`
- `content/images/articles/how-we-use-ai-like-engineers/big-diff-vs-small-drafts.svg`
- `content/images/articles/how-we-use-ai-like-engineers/context-belongs-in-different-places.svg`

</details>

<details>
<summary>Workflow documentation</summary>

- `docs/runbooks/blog-reposting.md`
- `AGENTS.md`
- `README.md`
- `docs/README.md`
- `site/README.md`

</details>

<details>
<summary>Related cleanup</summary>

- `content/articles/the-monolith-that-made-ai-actually-useful.md`

</details>

## How to test

```bash
cd site
pnpm check
pnpm build
```

### Manual spot checks

- open `/how-we-use-ai-like-engineers.html`
- confirm the canonical URL is `https://ashwch.com/how-we-use-ai-like-engineers.html`
- confirm all three SVGs load from `/images/articles/how-we-use-ai-like-engineers/...`
- confirm related article links use the personal-site `.html` route shape

## Notes

- Companion engineering-site PR: https://github.com/DiversioTeam/engineering-website/pull/3
- No schema, backend, or Worker changes.
