### PR TITLE
Standardize article end matter and refine AI article follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Root `content/` remains the source of truth.
 For article authoring and cross-site reposts with `engineering.diversio.com`, read:
 
 - `docs/runbooks/blog-reposting.md` — explains why `ashwch.com` owns the full article, why the engineering site keeps a short stub, and which files/commands to use
+- `docs/runbooks/article-end-matter.md` — standardized review acknowledgements and AI writing disclaimer blocks for article end matter
 
 If you touch photography-related flows, current helpers are:
 

--- a/content/articles/how-we-use-ai-like-engineers.md
+++ b/content/articles/how-we-use-ai-like-engineers.md
@@ -128,7 +128,7 @@ This does not mean we have not made mistakes. We have tried a lot of different t
 <figure>
   <img
     src="{static}/images/articles/how-we-use-ai-like-engineers/tool-history-vs-durable-workflow.svg"
-    alt="Diagram showing the path from copying and pasting out of ChatGPT and Claude, to GitHub Copilot, agentic IDEs where the team mostly used VS Code while some tried Cursor and later VS Code got agent mode, Claude Code, and then Codex CLI plus Pi, with a durable workflow layer underneath made up of repo context, scripts, skills, tests, review gates, and human habits."
+    alt="Diagram comparing tool history to a durable workflow layer."
     style="width:100%;height:auto;display:block;"
   />
   <figcaption>The workflow is not tightly coupled to the tool history.</figcaption>

--- a/content/articles/how-we-use-ai-like-engineers.md
+++ b/content/articles/how-we-use-ai-like-engineers.md
@@ -128,7 +128,7 @@ This does not mean we have not made mistakes. We have tried a lot of different t
 <figure>
   <img
     src="{static}/images/articles/how-we-use-ai-like-engineers/tool-history-vs-durable-workflow.svg"
-    alt="Diagram comparing tool history to a durable workflow layer."
+    alt="Diagram showing tools changing over time above a durable workflow layer of repo context, scripts, skills, tests, review gates, and human habits."
     style="width:100%;height:auto;display:block;"
   />
   <figcaption>The workflow is not tightly coupled to the tool history.</figcaption>

--- a/content/articles/how-we-use-ai-like-engineers.md
+++ b/content/articles/how-we-use-ai-like-engineers.md
@@ -121,17 +121,17 @@ The things I care about:
 
 DX is a big deal for me, more than the model itself.
 
-None of this has been a straight line. Before any of this felt structured, a lot of it was just copying and pasting code and plans out of [ChatGPT](https://chatgpt.com/) and [Claude](https://claude.ai/). Then came [GitHub Copilot](https://github.com/features/copilot) in 2024, mostly autocomplete and comment-driven code generation in VS Code. Some of us moved to [Cursor](https://cursor.com/). We jumped onto [Claude Code](https://www.anthropic.com/claude-code) very early because it fit the repo-exploration style better. Now the stack is more mixed and we are fine with that.
+None of this has been a straight line. Before any of this felt structured, a lot of it was just copying and pasting code and plans out of [ChatGPT](https://chatgpt.com/) and [Claude](https://claude.ai/). Then came [GitHub Copilot](https://github.com/features/copilot) in 2024, mostly autocomplete and comment-driven code generation in VS Code. Then came agentic IDEs, mostly VS Code, while some of us were trying [Cursor](https://cursor.com/) as well. Later, VS Code got agent mode too. We jumped onto [Claude Code](https://www.anthropic.com/claude-code) very early because it fit the repo-exploration style better. Now the stack is more mixed and we are fine with that.
 
 This does not mean we have not made mistakes. We have tried a lot of different things, but thanks to the team we were able to switch away from them when we realized something was not working for us. The important part is that the workflow is not tightly coupled to that tool history. The tools changed. The durable part stayed the same: repo instructions, skills, scripts, tests, review gates, and human habits. A recent example for us was moving a lot of the Claude Code-specific workflow into [Codex CLI](https://github.com/openai/codex) and [Pi](https://pi.dev/) within a week, without throwing away that layer.
 
 <figure>
   <img
     src="{static}/images/articles/how-we-use-ai-like-engineers/tool-history-vs-durable-workflow.svg"
-    alt="Diagram showing the path from copying and pasting out of ChatGPT and Claude, to GitHub Copilot, Cursor, Claude Code, and then Codex CLI plus Pi, with a durable workflow layer underneath made up of repo context, scripts, skills, tests, review gates, and human habits."
+    alt="Diagram showing the path from copying and pasting out of ChatGPT and Claude, to GitHub Copilot, agentic IDEs where the team mostly used VS Code while some tried Cursor and later VS Code got agent mode, Claude Code, and then Codex CLI plus Pi, with a durable workflow layer underneath made up of repo context, scripts, skills, tests, review gates, and human habits."
     style="width:100%;height:auto;display:block;"
   />
-  <figcaption>The tools changed. The workflow layer underneath kept getting stronger.</figcaption>
+  <figcaption>The workflow is not tightly coupled to the tool history.</figcaption>
 </figure>
 
 ## What changed for us
@@ -153,8 +153,13 @@ If you're wondering where to start to make the most of it with your own team, st
 - [No Code by Hand](/no-code-by-hand-agentic-platform-acceleration.html)
 - [Postman to Bruno: A Weekend Migration That Transformed Our API Workflow](/from-postman-to-bruno-how-ai-changed-our-api-workflow.html)
 
-<div class="ai-disclaimer">
-  <p class="ai-disclaimer-title">AI writing disclaimer</p>
+<div class="article-subtext article-subtext--review">
+  <p class="article-subtext-label">Review</p>
+  <p>Thanks to <a href="https://www.linkedin.com/in/ashishsiwal/">Ashish Siwal</a> and <a href="https://www.linkedin.com/in/umanga-bhattarai-579b68158/">Umanga Bhattarai</a> for reviewing this post.</p>
+</div>
+
+<div class="article-subtext article-subtext--ai">
+  <p class="article-subtext-label">AI writing disclaimer</p>
   <ul>
     <li>The article was verified for typos and basic grammatical mistakes using Codex 5.4.</li>
     <li>The references to our existing blog posts were included with the help of Codex 5.4 (we left comments for it).</li>

--- a/content/articles/protecting-our-own-tenant-in-a-multi-tenant-saas.md
+++ b/content/articles/protecting-our-own-tenant-in-a-multi-tenant-saas.md
@@ -442,6 +442,9 @@ The key point is not that we use Django or Postgres or AWS specifically. The key
 
 Together, these give us something stronger than "trust us, we will be careful" and they do it in a way that a small, focused team can maintain while still shipping features.
 
-*Thanks to [Ashish Siwal](https://www.linkedin.com/in/ashishsiwal/) for reviewing this post and helping solidify the implementation.*
+<div class="article-subtext article-subtext--review">
+  <p class="article-subtext-label">Review</p>
+  <p>Thanks to <a href="https://www.linkedin.com/in/ashishsiwal/">Ashish Siwal</a> for reviewing this post and helping solidify the implementation.</p>
+</div>
 
 [^dogfood]: "Dogfooding" just means using your own product internally for real, day-to-day work, so you hit the same pain points and edge cases your customers do.

--- a/content/articles/the-monolith-that-made-ai-actually-useful.md
+++ b/content/articles/the-monolith-that-made-ai-actually-useful.md
@@ -205,4 +205,7 @@ You've built a competitive advantage.
 
 Want to dive deeper into Git worktrees? Check out my comprehensive guide: [Git Worktrees: From Zero to Hero](https://gist.github.com/ashwch/946ad983977c9107db7ee9abafeb95bd). It covers everything from first principles to advanced workflows with submodules.
 
-*Thanks to [Samuel Bonin](https://www.linkedin.com/in/samuel-bonin/) and [Amal Raj](https://www.linkedin.com/in/amalraj-offl/) for reviewing this post.*
+<div class="article-subtext article-subtext--review">
+  <p class="article-subtext-label">Review</p>
+  <p>Thanks to <a href="https://www.linkedin.com/in/samuel-bonin/">Samuel Bonin</a> and <a href="https://www.linkedin.com/in/amalraj-offl/">Amal Raj</a> for reviewing this post.</p>
+</div>

--- a/content/images/articles/how-we-use-ai-like-engineers/tool-history-vs-durable-workflow.svg
+++ b/content/images/articles/how-we-use-ai-like-engineers/tool-history-vs-durable-workflow.svg
@@ -39,9 +39,9 @@
   <line x1="380" y1="222" x2="416" y2="222" stroke="#2f3640" stroke-width="2" marker-end="url(#arrow)" />
 
   <rect x="424" y="164" width="144" height="116" rx="14" fill="#f7f8fa" stroke="#2f3640" stroke-width="2" />
-  <text x="450" y="210" class="label">Cursor</text>
-  <text x="446" y="248" class="item">More interactive</text>
-  <text x="446" y="268" class="item">editor flow</text>
+  <text x="436" y="210" class="label">Agentic IDEs</text>
+  <text x="438" y="248" class="item">VS Code + Cursor</text>
+  <text x="443" y="268" class="item">later agent mode</text>
 
   <line x1="568" y1="222" x2="604" y2="222" stroke="#2f3640" stroke-width="2" marker-end="url(#arrow)" />
 
@@ -51,13 +51,13 @@
   <text x="638" y="248" class="item">Repo exploration</text>
   <text x="638" y="268" class="item">terminal-first</text>
 
-  <line x1="756" y1="222" x2="772" y2="222" stroke="#2f3640" stroke-width="2" marker-end="url(#arrow)" />
+  <line x1="756" y1="222" x2="784" y2="222" stroke="#2f3640" stroke-width="2" marker-end="url(#arrow)" />
 
-  <rect x="780" y="164" width="132" height="116" rx="14" fill="#f7f8fa" stroke="#2f3640" stroke-width="2" />
-  <text x="809" y="198" class="label">Codex</text>
-  <text x="800" y="222" class="label">CLI + Pi</text>
-  <text x="796" y="248" class="item">Same workflow</text>
-  <text x="802" y="268" class="item">new harness</text>
+  <rect x="796" y="164" width="132" height="116" rx="14" fill="#f7f8fa" stroke="#2f3640" stroke-width="2" />
+  <text x="825" y="198" class="label">Codex</text>
+  <text x="816" y="222" class="label">CLI + Pi</text>
+  <text x="812" y="248" class="item">Same workflow</text>
+  <text x="818" y="268" class="item">new harness</text>
 
   <text x="48" y="342" class="small">DURABLE LAYER</text>
   <rect x="48" y="362" width="864" height="132" rx="18" fill="#eceff3" />
@@ -76,7 +76,6 @@
   <line x1="308" y1="280" x2="308" y2="362" stroke="#2f3640" stroke-width="2" stroke-dasharray="6 6" />
   <line x1="496" y1="280" x2="496" y2="362" stroke="#2f3640" stroke-width="2" stroke-dasharray="6 6" />
   <line x1="684" y1="280" x2="684" y2="362" stroke="#2f3640" stroke-width="2" stroke-dasharray="6 6" />
-  <line x1="846" y1="280" x2="846" y2="362" stroke="#2f3640" stroke-width="2" stroke-dasharray="6 6" />
+  <line x1="862" y1="280" x2="862" y2="362" stroke="#2f3640" stroke-width="2" stroke-dasharray="6 6" />
 
-  <text x="78" y="466" class="item">That is what let us switch tools without throwing away what we had already built.</text>
 </svg>

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This directory contains current project documentation for the Astro-based `ashwc
 
 ### Runbooks and workflow docs
 - `runbooks/blog-reposting.md`
+- `runbooks/article-end-matter.md`
 - `workflows/PHOTOGRAPHY_WORKFLOW.md`
 
 ## Historical docs

--- a/docs/runbooks/article-end-matter.md
+++ b/docs/runbooks/article-end-matter.md
@@ -1,0 +1,112 @@
+# Article End Matter
+
+Use this runbook when an article needs standardized footer-style notes at the end of the post.
+
+Current supported blocks:
+
+- review acknowledgements
+- AI writing disclaimers
+
+## Why this exists
+
+These notes were starting to show up in different formats across posts.
+
+The goal is to keep them:
+
+- visually consistent
+- easy to paste into future posts
+- separate from the main article body
+- subtle enough to read like end matter, not like a giant callout
+
+## Source of truth
+
+Edit root content files only:
+
+- `content/articles/*.md`
+
+Do not hand-edit generated Astro content under:
+
+- `site/src/content/articles/*.md`
+
+## Styling
+
+Shared styling lives in:
+
+- `site/src/styles/global.css`
+
+The shared wrapper class is:
+
+- `article-subtext`
+
+Current modifiers are:
+
+- `article-subtext--review`
+- `article-subtext--ai`
+
+## Standard snippets
+
+### Review acknowledgement
+
+Use raw HTML here so links are explicit and the block keeps one consistent structure.
+
+```html
+<div class="article-subtext article-subtext--review">
+  <p class="article-subtext-label">Review</p>
+  <p>Thanks to <a href="https://www.linkedin.com/in/person-one/">Person One</a> and <a href="https://www.linkedin.com/in/person-two/">Person Two</a> for reviewing this post.</p>
+</div>
+```
+
+If only one reviewer is involved, keep the same structure and remove the second name.
+
+If the acknowledgement needs one short extra clause, keep it practical and concise, for example:
+
+```html
+<div class="article-subtext article-subtext--review">
+  <p class="article-subtext-label">Review</p>
+  <p>Thanks to <a href="https://www.linkedin.com/in/person-one/">Person One</a> for reviewing this post and helping solidify the implementation.</p>
+</div>
+```
+
+### AI writing disclaimer
+
+```html
+<div class="article-subtext article-subtext--ai">
+  <p class="article-subtext-label">AI writing disclaimer</p>
+  <ul>
+    <li>The article was verified for typos and basic grammatical mistakes using ...</li>
+    <li>References or supporting links were gathered with the help of ...</li>
+    <li>Images, SVGs, or diagrams were generated using ...</li>
+  </ul>
+</div>
+```
+
+## Placement rules
+
+Place these blocks near the end of the article, after the main content.
+
+Good placements:
+
+- after a `Related reading` section
+- after a short closing paragraph
+- before footnotes only when the acknowledgement is directly tied to the article body
+
+## Tone rules
+
+Keep these sections simple.
+
+- no hype
+- no long thank-you speeches
+- no marketing phrasing
+- no apology tone
+- no over-explaining AI usage
+
+These are end notes, not a second conclusion.
+
+## Validation
+
+From `site/` run:
+
+```bash
+pnpm check
+pnpm build
+```

--- a/docs/runbooks/blog-reposting.md
+++ b/docs/runbooks/blog-reposting.md
@@ -120,6 +120,10 @@ So:
 - do **not** hand-edit `site/src/content/articles/*.md`
 - do **not** switch one article to YAML frontmatter unless the pipeline changes
 
+If the article needs reviewer acknowledgements or an AI writing disclaimer, use:
+
+- `docs/runbooks/article-end-matter.md`
+
 ### Step 2: Add article images in the right place
 
 Create:

--- a/site/scripts/sync-static-assets.mjs
+++ b/site/scripts/sync-static-assets.mjs
@@ -13,6 +13,8 @@ const TARGET_IMAGES = path.join(PUBLIC_DIR, 'images');
 const TARGET_CNAME = path.join(PUBLIC_DIR, 'CNAME');
 
 async function replacePath(tempPath, targetPath, removeOptions) {
+  let lastReplaceError;
+
   for (let attempt = 0; attempt < 3; attempt += 1) {
     await rm(targetPath, removeOptions);
     try {
@@ -22,10 +24,14 @@ async function replacePath(tempPath, targetPath, removeOptions) {
       if (!['EEXIST', 'ENOTEMPTY'].includes(error.code)) {
         throw error;
       }
+      lastReplaceError = error;
     }
   }
 
-  throw new Error(`Could not replace ${targetPath} after multiple attempts.`);
+  const errorDetails = lastReplaceError
+    ? ` Last error: ${lastReplaceError.code ?? 'UNKNOWN'}${lastReplaceError.message ? ` - ${lastReplaceError.message}` : ''}`
+    : '';
+  throw new Error(`Could not replace ${targetPath} after 3 attempts.${errorDetails}`);
 }
 
 async function main() {

--- a/site/scripts/sync-static-assets.mjs
+++ b/site/scripts/sync-static-assets.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, rm } from 'node:fs/promises';
+import { cp, mkdir, rename, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -12,18 +12,49 @@ const SOURCE_CNAME = path.join(REPO_ROOT, 'content', 'extra', 'CNAME');
 const TARGET_IMAGES = path.join(PUBLIC_DIR, 'images');
 const TARGET_CNAME = path.join(PUBLIC_DIR, 'CNAME');
 
+async function replacePath(tempPath, targetPath, removeOptions) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await rm(targetPath, removeOptions);
+    try {
+      await rename(tempPath, targetPath);
+      return;
+    } catch (error) {
+      if (!['EEXIST', 'ENOTEMPTY'].includes(error.code)) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(`Could not replace ${targetPath} after multiple attempts.`);
+}
+
 async function main() {
   await mkdir(PUBLIC_DIR, { recursive: true });
-  await rm(TARGET_IMAGES, { recursive: true, force: true });
-  await cp(SOURCE_IMAGES, TARGET_IMAGES, {
-    recursive: true,
-    force: true,
-    filter(source) {
-      return !source.endsWith('.DS_Store');
-    },
-  });
-  await cp(SOURCE_CNAME, TARGET_CNAME, { force: true });
-  console.log('Synced static assets into Astro public/.');
+
+  const tempImagesDir = path.join(PUBLIC_DIR, `.images-sync-${process.pid}-${Date.now()}`);
+  const tempCnamePath = path.join(PUBLIC_DIR, `.CNAME-sync-${process.pid}-${Date.now()}`);
+
+  await rm(tempImagesDir, { recursive: true, force: true });
+  await rm(tempCnamePath, { force: true });
+
+  try {
+    await cp(SOURCE_IMAGES, tempImagesDir, {
+      recursive: true,
+      force: true,
+      filter(source) {
+        return !source.endsWith('.DS_Store');
+      },
+    });
+    await cp(SOURCE_CNAME, tempCnamePath, { force: true });
+
+    await replacePath(tempImagesDir, TARGET_IMAGES, { recursive: true, force: true });
+    await replacePath(tempCnamePath, TARGET_CNAME, { force: true });
+
+    console.log('Synced static assets into Astro public/.');
+  } finally {
+    await rm(tempImagesDir, { recursive: true, force: true });
+    await rm(tempCnamePath, { force: true });
+  }
 }
 
 main().catch((error) => {

--- a/site/scripts/sync-static-assets.mjs
+++ b/site/scripts/sync-static-assets.mjs
@@ -12,19 +12,56 @@ const SOURCE_CNAME = path.join(REPO_ROOT, 'content', 'extra', 'CNAME');
 const TARGET_IMAGES = path.join(PUBLIC_DIR, 'images');
 const TARGET_CNAME = path.join(PUBLIC_DIR, 'CNAME');
 
+async function movePathIfItExists(sourcePath, destinationPath) {
+  try {
+    await rename(sourcePath, destinationPath);
+    return true;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function restoreBackup(backupPath, targetPath, removeOptions) {
+  await rm(targetPath, removeOptions);
+  try {
+    await rename(backupPath, targetPath);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
 async function replacePath(tempPath, targetPath, removeOptions) {
   let lastReplaceError;
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    await rm(targetPath, removeOptions);
+    const backupPath = path.join(
+      path.dirname(targetPath),
+      `.${path.basename(targetPath)}.backup-${process.pid}-${Date.now()}-${attempt}`,
+    );
+    let movedOriginalTarget = false;
+
     try {
+      movedOriginalTarget = await movePathIfItExists(targetPath, backupPath);
       await rename(tempPath, targetPath);
+      await rm(backupPath, removeOptions);
       return;
     } catch (error) {
-      if (!['EEXIST', 'ENOTEMPTY'].includes(error.code)) {
-        throw error;
-      }
       lastReplaceError = error;
+
+      if (movedOriginalTarget) {
+        await restoreBackup(backupPath, targetPath, removeOptions);
+      }
+
+      if (!['EEXIST', 'ENOTEMPTY'].includes(error.code)) {
+        break;
+      }
+    } finally {
+      await rm(backupPath, removeOptions);
     }
   }
 

--- a/site/scripts/sync-static-assets.mjs
+++ b/site/scripts/sync-static-assets.mjs
@@ -35,6 +35,14 @@ async function restoreBackup(backupPath, targetPath, removeOptions) {
   }
 }
 
+async function removePathBestEffort(targetPath, removeOptions) {
+  try {
+    await rm(targetPath, removeOptions);
+  } catch (error) {
+    console.warn(`Best-effort cleanup failed for ${targetPath}: ${error.code ?? 'UNKNOWN'}${error.message ? ` - ${error.message}` : ''}`);
+  }
+}
+
 async function replacePath(tempPath, targetPath, removeOptions) {
   let lastReplaceError;
 
@@ -44,16 +52,18 @@ async function replacePath(tempPath, targetPath, removeOptions) {
       `.${path.basename(targetPath)}.backup-${process.pid}-${Date.now()}-${attempt}`,
     );
     let movedOriginalTarget = false;
+    let swapSucceeded = false;
 
     try {
       movedOriginalTarget = await movePathIfItExists(targetPath, backupPath);
       await rename(tempPath, targetPath);
-      await rm(backupPath, removeOptions);
+      swapSucceeded = true;
+      await removePathBestEffort(backupPath, removeOptions);
       return;
     } catch (error) {
       lastReplaceError = error;
 
-      if (movedOriginalTarget) {
+      if (movedOriginalTarget && !swapSucceeded) {
         await restoreBackup(backupPath, targetPath, removeOptions);
       }
 
@@ -61,7 +71,7 @@ async function replacePath(tempPath, targetPath, removeOptions) {
         break;
       }
     } finally {
-      await rm(backupPath, removeOptions);
+      await removePathBestEffort(backupPath, removeOptions);
     }
   }
 

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1120,6 +1120,55 @@ select {
   margin: 2.5rem 0;
 }
 
+.prose .article-subtext {
+  margin: 2rem 0 0;
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-left-width: 4px;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-subtle) 72%, var(--bg-elevated));
+  font-family: var(--font-sans);
+}
+
+.prose .article-subtext + .article-subtext {
+  margin-top: 1rem;
+}
+
+.prose .article-subtext--review {
+  border-left-color: var(--border-strong);
+}
+
+.prose .article-subtext--ai {
+  border-left-color: var(--accent);
+  background: color-mix(in srgb, var(--accent-soft) 32%, var(--bg-elevated));
+}
+
+.prose .article-subtext > p:not(.article-subtext-label),
+.prose .article-subtext > ul {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.98rem;
+  line-height: 1.7;
+}
+
+.prose .article-subtext-label {
+  margin: 0 0 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-soft);
+}
+
+.prose .article-subtext > ul {
+  margin-top: 0.55rem;
+  padding-left: 1.25rem;
+}
+
+.prose .article-subtext li + li {
+  margin-top: 0.35rem;
+}
+
 .heading-anchor {
   margin-left: 0.35rem;
   opacity: 0;


### PR DESCRIPTION
## Summary

This PR standardizes article end matter across the Astro site, updates the AI engineering article follow-up content, and hardens the local asset sync script so repeated validation runs stop tripping over each other.

### Key Features

| Feature | Description |
| --- | --- |
| **Standard end matter blocks** | Adds reusable review-acknowledgement and AI writing disclaimer blocks with shared styling and a dedicated runbook. |
| **Article updates** | Applies the new end-matter format to existing articles and refines the AI engineering article copy + workflow-history diagram. |
| **Safer asset syncing** | Makes `sync-static-assets.mjs` use temp paths + replace semantics so concurrent or repeated local checks do not hit `EEXIST` / `ENOTEMPTY` races. |

## Visual overview

### Article end matter flow

```text
content/articles/*.md
        │
        │ reusable HTML blocks
        ▼
site/src/styles/global.css
        │
        │ shared article-subtext styles
        ▼
Rendered article pages
        ├─ Review acknowledgement
        └─ AI writing disclaimer
```

### Asset sync behavior

```text
content/images + content/extra/CNAME
                │
                ▼
   temp sync paths under site/public/
                │
                ▼
      atomic-ish replace into:
      - site/public/images
      - site/public/CNAME
```

---

## Detailed changes

### 1. Standardize article end matter

Added a dedicated end-matter pattern for article footer notes:

- `article-subtext article-subtext--review`
- `article-subtext article-subtext--ai`

This keeps reviewer acknowledgements and AI disclaimers visually consistent and easier to reuse in future posts.

### 2. Document the workflow

Added `docs/runbooks/article-end-matter.md` and linked it from repo docs so future article work has one standard snippet source.

### 3. Apply the pattern to existing content

Updated:

- `how-we-use-ai-like-engineers`
- `the-monolith-that-made-ai-actually-useful`
- `protecting-our-own-tenant-in-a-multi-tenant-saas`

The AI engineering article also gets the follow-up copy edits around:

- tool-history phrasing
- agentic IDE wording
- review credits
- AI disclaimer presentation
- workflow history diagram copy

### 4. Fix the local sync race

The old asset sync script deleted `site/public/images` and copied directly into place. Under repeated local validation, that could still race and fail with filesystem errors.

The new flow:

- copies into unique temp paths
- retries replace on `EEXIST` / `ENOTEMPTY`
- cleans up temp paths in `finally`

This makes local verification much more stable without changing the site output.

## Files changed

<details>
<summary>Content + image updates</summary>

- `content/articles/how-we-use-ai-like-engineers.md` - refines the AI article and adds standardized end matter
- `content/articles/the-monolith-that-made-ai-actually-useful.md` - converts review thanks to the standard block
- `content/articles/protecting-our-own-tenant-in-a-multi-tenant-saas.md` - converts review thanks to the standard block
- `content/images/articles/how-we-use-ai-like-engineers/tool-history-vs-durable-workflow.svg` - updates workflow-history diagram copy/layout

</details>

<details>
<summary>Docs + repo guidance</summary>

- `docs/runbooks/article-end-matter.md` - new reusable end-matter runbook
- `docs/runbooks/blog-reposting.md` - points article authors to the new runbook
- `docs/README.md` - indexes the new runbook
- `AGENTS.md` - links the new authoring guidance

</details>

<details>
<summary>Site styling + scripts</summary>

- `site/src/styles/global.css` - shared styling for article end matter
- `site/scripts/sync-static-assets.mjs` - temp-path replacement + cleanup hardening

</details>

## How to test

```bash
cd site
node ./scripts/migrate-pelican-content.mjs
node ./scripts/sync-static-assets.mjs
./node_modules/.bin/astro check
./node_modules/.bin/astro build
```

### Manual checks

1. Open `how-we-use-ai-like-engineers.html` and verify:
   - review acknowledgement renders as subtext
   - AI writing disclaimer renders as subtext
   - workflow history diagram copy matches the article text
2. Open the monolith and protecting-tenant articles and verify reviewer acknowledgements use the same formatting.
3. Re-run the sync/build flow more than once and confirm `sync-static-assets.mjs` no longer fails with `EEXIST` / `ENOTEMPTY`.

## Notes

- No dependency changes
- No schema or migration changes
- No related GitHub issue was open for this follow-up
